### PR TITLE
Refactor JWT secret handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mita
 JWT_SECRET=dev_secret_change
+SECRET_KEY=dev_secret_change
 REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ MITA distributes a user’s **monthly income** into **daily budgets per category
 ```
 GOOGLE_CREDENTIALS_PATH=/path/to/ocr.json
 FIREBASE_CONFIGURED=true
-JWT_SECRET_KEY=supersecret
+SECRET_KEY=supersecret
 DATABASE_URL=postgresql://user:pass@localhost:5432/mita
 ```
 

--- a/app/core/jwt_utils.py
+++ b/app/core/jwt_utils.py
@@ -1,11 +1,13 @@
-import os, datetime, uuid
+import os
+import datetime
+import uuid
 import jwt
 from passlib.context import CryptContext
 
-SECRET_KEY=os.getenv "oPh-TW4BNM9vQc2S8DkP0XYhIMeJBS5vMBRT6s9aQ1_rBjhsSTP3adTUxKMZ-cvq6UabCJSEpUaaBMzqAHXbzA"
-ALGORITHM="HS256"
-ACCESS_EXPIRES_MIN=30
-REFRESH_EXPIRES_DAYS=7
+from app.core.config import SECRET_KEY, ALGORITHM, settings
+
+ACCESS_EXPIRES_MIN = settings.ACCESS_TOKEN_EXPIRE_MINUTES
+REFRESH_EXPIRES_DAYS = 7
 
 pwd_context=CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/app/services/auth_jwt_service.py
+++ b/app/services/auth_jwt_service.py
@@ -2,9 +2,9 @@
 from datetime import datetime, timedelta
 from jose import JWTError, jwt
 
-SECRET_KEY = "REPLACE_ME"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+from app.core.config import SECRET_KEY, ALGORITHM, settings
+
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 
 # Можно заменить на хранилище в Redis/DB


### PR DESCRIPTION
## Summary
- centralize JWT secret config in `settings`
- document SECRET_KEY usage
- show example SECRET_KEY in `.env.example`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fac9149c832295daf3db5d3a9278