### PR TITLE
Implement auto budget update on transaction save

### DIFF
--- a/app/api/transactions.py
+++ b/app/api/transactions.py
@@ -10,6 +10,7 @@ from app.api.dependencies import get_current_user
 from app.core.session import get_db
 from app.db.models import Transaction
 from app.schemas.core_outputs import TransactionOut
+from app.services.core.engine.expense_tracker import apply_transaction_to_plan
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
@@ -38,6 +39,7 @@ def add_txn(
     db.add(t)
     db.commit()
     db.refresh(t)
+    apply_transaction_to_plan(db, t)
     return success_response({"id": str(t.id)})
 
 

--- a/app/services/core/engine/expense_tracker.py
+++ b/app/services/core/engine/expense_tracker.py
@@ -1,17 +1,51 @@
-
-from sqlalchemy.orm import Session
 from datetime import date
 from decimal import Decimal
-from app.db.models import Transaction, DailyPlan
+
+from sqlalchemy.orm import Session
+
+from app.db.models import DailyPlan, Transaction
 from app.services.core.engine.calendar_updater import update_day_status
 
-def record_expense(db: Session, user_id: int, day: date, category: str, amount: float, description: str = ""):
+
+def apply_transaction_to_plan(db: Session, txn: Transaction) -> None:
+    """Apply an already saved transaction to the DailyPlan table."""
+    txn_day = txn.spent_at.date()
+
+    plan = (
+        db.query(DailyPlan)
+        .filter_by(user_id=txn.user_id, date=txn_day, category=txn.category)
+        .first()
+    )
+    if plan:
+        plan.spent_amount += txn.amount
+    else:
+        new_plan = DailyPlan(
+            user_id=txn.user_id,
+            date=txn_day,
+            category=txn.category,
+            planned_amount=Decimal("0.00"),
+            spent_amount=txn.amount,
+        )
+        db.add(new_plan)
+
+    db.commit()
+    update_day_status(db, txn.user_id, txn_day)
+
+
+def record_expense(
+    db: Session,
+    user_id: int,
+    day: date,
+    category: str,
+    amount: float,
+    description: str = "",
+):
     txn = Transaction(
         user_id=user_id,
         date=day,
         category=category,
         amount=Decimal(amount),
-        description=description
+        description=description,
     )
     db.add(txn)
 
@@ -28,7 +62,7 @@ def record_expense(db: Session, user_id: int, day: date, category: str, amount: 
             date=day,
             category=category,
             planned_amount=Decimal("0.00"),
-            spent_amount=Decimal(amount)
+            spent_amount=Decimal(amount),
         )
         db.add(new_plan)
 
@@ -40,5 +74,5 @@ def record_expense(db: Session, user_id: int, day: date, category: str, amount: 
         "status": "recorded",
         "date": day.isoformat(),
         "category": category,
-        "amount": float(amount)
+        "amount": float(amount),
     }


### PR DESCRIPTION
## Summary
- add `apply_transaction_to_plan` helper in expense tracker
- auto-apply new transaction to daily plan in `/transactions` endpoint

## Testing
- `pre-commit run --files app/api/transactions.py app/services/core/engine/expense_tracker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6b0a44c08322b6d5471710baedda