### PR TITLE
Fix Firebase init duplication

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -53,10 +53,15 @@ from app.core.limiter_setup import init_rate_limiter
 from app.utils.response_wrapper import error_response
 
 # ---- Firebase Admin SDK init ----
-firebase_json = os.environ["FIREBASE_JSON"]
-cred_dict = json.loads(firebase_json)
-cred = credentials.Certificate(cred_dict)
-firebase_admin.initialize_app(cred)
+# Initialize Firebase only once. Other modules may do so as well,
+# but firebase_admin throws an error if `initialize_app` is called
+# multiple times without an app name. Guard the call to avoid this
+# issue during application startup.
+if not firebase_admin._apps:
+    firebase_json = os.environ["FIREBASE_JSON"]
+    cred_dict = json.loads(firebase_json)
+    cred = credentials.Certificate(cred_dict)
+    firebase_admin.initialize_app(cred)
 
 # ---- Sentry setup ----
 sentry_sdk.init(


### PR DESCRIPTION
## Summary
- avoid calling `firebase_admin.initialize_app` multiple times

## Testing
- `pip install -r requirements.txt` *(fails: Getting requirements to build wheel did not run successfully)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6864236b98188322b17fc932c63b6018