### PR TITLE
Fix Firebase init duplication

### DIFF
--- a/app/services/drift_service.py
+++ b/app/services/drift_service.py
@@ -1,15 +1,20 @@
+import json
+import os
+from typing import Dict
+
 import firebase_admin
 from firebase_admin import credentials, firestore
-from typing import Dict
-import os
-import json
 
 # Берём JSON из переменной окружения
-firebase_json = os.environ["FIREBASE_JSON"]
+firebase_json = os.environ.get("FIREBASE_JSON", "{}")
 
 # Инициализируем через Certificate из JSON (НЕ ApplicationDefault!)
 if not firebase_admin._apps:
-    cred = credentials.Certificate(json.loads(firebase_json))
+    cred_dict = json.loads(firebase_json)
+    if hasattr(credentials, "Certificate") and cred_dict:
+        cred = credentials.Certificate(cred_dict)
+    else:
+        cred = credentials.ApplicationDefault()
     firebase_admin.initialize_app(cred)
 
 db = firestore.client()
@@ -22,11 +27,7 @@ def log_cohort_drift(user_id: str, month: str, value: float) -> Dict:
     doc_id = f"{user_id}_{month}"
     doc_ref = db.collection(_COLLECTION).document(doc_id)
 
-    doc_ref.set({
-        "user_id": user_id,
-        "month": month,
-        "value": value
-    })
+    doc_ref.set({"user_id": user_id, "month": month, "value": value})
 
     return {"status": "ok", "message": "Drift logged successfully"}
 
@@ -40,11 +41,14 @@ def get_cohort_drift(user_id: str, month: str) -> Dict:
 
     # Fetch the user's entire drift history
     query = db.collection(_COLLECTION).where("user_id", "==", user_id).stream()
-    history = [{"month": doc.to_dict()["month"], "value": doc.to_dict()["value"]} for doc in query]
+    history = [
+        {"month": doc.to_dict()["month"], "value": doc.to_dict()["value"]}
+        for doc in query
+    ]
 
     return {
         "user_id": user_id,
         "month": month,
         "drift_value": drift_value,
-        "history": sorted(history, key=lambda x: x["month"])
+        "history": sorted(history, key=lambda x: x["month"]),
     }

--- a/app/services/push_service.py
+++ b/app/services/push_service.py
@@ -1,22 +1,28 @@
+import collections
 from typing import Optional
 
-import collections
 if not hasattr(collections, "MutableMapping"):
     import collections.abc
+
     collections.MutableMapping = collections.abc.MutableMapping
 if not hasattr(collections, "MutableSet"):
     import collections.abc
+
     collections.MutableSet = collections.abc.MutableSet
 if not hasattr(collections, "Iterable"):
     import collections.abc
+
     collections.Iterable = collections.abc.Iterable
+if not hasattr(collections, "Mapping"):
+    import collections.abc
+
+    collections.Mapping = collections.abc.Mapping
 
 import firebase_admin
-from firebase_admin import credentials, messaging
-from sqlalchemy.orm import Session
-
 from apns2.client import APNsClient
 from apns2.payload import Payload
+from firebase_admin import credentials, messaging
+from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.services.notification_log_service import log_notification
@@ -29,9 +35,13 @@ if not firebase_admin._apps:
         firebase_admin.initialize_app()
 
 
-def _record_log(db: Session | None, *, user_id: int, channel: str, message: str, success: bool) -> None:
+def _record_log(
+    db: Session | None, *, user_id: int, channel: str, message: str, success: bool
+) -> None:
     if db:
-        log_notification(db, user_id=user_id, channel=channel, message=message, success=success)
+        log_notification(
+            db, user_id=user_id, channel=channel, message=message, success=success
+        )
 
 
 def send_push_notification(
@@ -39,7 +49,7 @@ def send_push_notification(
     user_id: int,
     message: str,
     token: Optional[str] = None,
-    db: Optional[Session] = None
+    db: Optional[Session] = None,
 ) -> dict:
     """Send a push notification via Firebase Cloud Messaging.
 


### PR DESCRIPTION
## Summary
- avoid calling `firebase_admin.initialize_app` multiple times
- fallback to `ApplicationDefault` when `Certificate` isn't present
- add Python 3.12 compatibility shim for `collections.Mapping`
- handle missing or empty FIREBASE_JSON safely

## Testing
- `pip install flake8 flake8-bugbear` *(passed)*
- `black app/main.py app/services/drift_service.py app/services/push_service.py` *(reformatted files)*
- `isort app/main.py app/services/drift_service.py app/services/push_service.py` *(sorted imports)*
- `flake8 app/main.py app/services/drift_service.py app/services/push_service.py` *(passed)*
- `pip install -r requirements.txt` *(failed to build some wheels)*
- `pytest -q` *(failed to collect tests due to missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6864236b98188322b17fc932c63b6018