### PR TITLE
Add widget tests for major screens

### DIFF
--- a/mobile_app/test/calendar_screen_test.dart
+++ b/mobile_app/test/calendar_screen_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/calendar_screen.dart';
+
+void main() {
+  testWidgets('Calendar shows loading indicator initially', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: CalendarScreen()));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}

--- a/mobile_app/test/dashboard_screen_test.dart
+++ b/mobile_app/test/dashboard_screen_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/main_screen.dart';
+
+void main() {
+  testWidgets('Dashboard shows loading indicator initially', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: MainScreen()));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}

--- a/mobile_app/test/login_screen_test.dart
+++ b/mobile_app/test/login_screen_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/login_screen.dart';
+
+void main() {
+  testWidgets('Login screen displays sign in button', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: LoginScreen()));
+
+    expect(find.text('Sign in to MITA'), findsOneWidget);
+    expect(find.text('Sign in with Google'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget tests for Login, Dashboard, and Calendar screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864621d3c808322aebc00baddae9353