### PR TITLE
Configure API_BASE_URL for mobile app

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -14,3 +14,15 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Configuration
+
+`ApiService` reads the backend URL from the `API_BASE_URL` Dart define. The
+default in `lib/config.dart` is `http://localhost:8000`, which works with the
+Docker compose setup. To point the app at a production backend run Flutter with
+
+```bash
+flutter build apk --dart-define=API_BASE_URL=https://api.example.com
+```
+
+Replace the URL with your deployment.

--- a/mobile_app/lib/config.dart
+++ b/mobile_app/lib/config.dart
@@ -1,0 +1,1 @@
+const String defaultApiBaseUrl = 'http://localhost:8000';

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import '../config.dart';
 
 class ApiService {
   ApiService() {
@@ -33,9 +34,12 @@ class ApiService {
     );
   }
 
+  final String _baseUrl =
+      const String.fromEnvironment('API_BASE_URL', defaultValue: defaultApiBaseUrl);
+
   final Dio _dio = Dio(
     BaseOptions(
-      baseUrl: 'https://mita-docker-ready-project-manus.onrender.com',
+      baseUrl: _baseUrl,
       connectTimeout: const Duration(seconds: 20),
       receiveTimeout: const Duration(seconds: 20),
       contentType: 'application/json',


### PR DESCRIPTION
## Summary
- allow configuring API base URL via `API_BASE_URL` dart define
- document API URL override in mobile app README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864621796d88322a3cbf68c1b60cc4e