### PR TITLE
Fix fastapi limiter import

### DIFF
--- a/app/core/limiter_setup.py
+++ b/app/core/limiter_setup.py
@@ -1,6 +1,5 @@
 from fastapi import FastAPI
 from fastapi_limiter import FastAPILimiter
-from fastapi_limiter.depends import get_remote_address
 import redis.asyncio as redis
 
 
@@ -18,7 +17,6 @@ async def init_rate_limiter(app: FastAPI):
     await FastAPILimiter.init(
         redis_client,
         prefix="FASTAPI_LIMITER",
-        identifier=get_remote_address  # ✅ Импортируешь и используешь
     )
 
     @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- clean up limiter setup to use default identifier

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865ad207fd48322a8ed1e793ab714a2