### PR TITLE
Fix async engine url handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Example configuration for local development. Replace values as needed.
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mita
+# Use the asyncpg driver so SQLAlchemy's async engine works out of the box.
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/mita
 JWT_SECRET=dev_secret_change
 SECRET_KEY=dev_secret_change  # replace with a strong value in production
 JWT_PREVIOUS_SECRET=

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ Example:
 GOOGLE_CREDENTIALS_PATH=/path/to/ocr.json
 FIREBASE_CONFIGURED=true
 SECRET_KEY=change_me
-DATABASE_URL=postgresql://user:pass@localhost:5432/mita
+# Use the asyncpg driver for SQLAlchemy's async engine
+DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/mita
 SMTP_HOST=mail.example.com
 SMTP_PORT=587
 SMTP_USERNAME=mailer

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,12 +1,24 @@
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
+
 from app.core.config import settings
-from app.db.base import Base  # <-- Импортируем ТОЛЬКО Base
+
+# Import Base so that Alembic can discover models; it's unused directly here.
+from app.db.base import Base  # noqa: F401
 
 DATABASE_URL = settings.DATABASE_URL
 
+# Ensure that an async driver is used even if the provided DATABASE_URL is
+# synchronous (e.g. ``postgresql://``). ``alembic upgrade`` would otherwise
+# fail with ``InvalidRequestError: The asyncio extension requires an async
+# driver to be used``.
+url = make_url(DATABASE_URL)
+if url.drivername in ["postgresql", "postgresql+psycopg2"]:
+    url = url.set(drivername="postgresql+asyncpg")
+
 engine = create_async_engine(
-    DATABASE_URL,
+    url.render_as_string(hide_password=False),
     future=True,
     echo=False,
 )
@@ -16,6 +28,7 @@ async_session = sessionmaker(
     class_=AsyncSession,
     expire_on_commit=False,
 )
+
 
 async def get_db():
     async with async_session() as session:


### PR DESCRIPTION
## Summary
- ensure the async DB engine uses an async driver automatically
- update sample environment variables
- clarify README instructions for the database URL

## Testing
- `pre-commit run --files app/core/db.py README.md .env.example`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866d674c6648322941227a54f4155d9