### PR TITLE
Fix login API path

### DIFF
--- a/mobile_app/lib/config.dart
+++ b/mobile_app/lib/config.dart
@@ -1,1 +1,1 @@
-const String defaultApiBaseUrl = 'https://mita-docker-ready-project-manus.onrender.com/api/v0';
+const String defaultApiBaseUrl = 'https://mita-docker-ready-project-manus.onrender.com/api';

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -74,7 +74,7 @@ class ApiService {
     if (refresh == null) return false;
     try {
       final response = await _dio.post(
-        '/auth/auth/refresh',
+        '/auth/refresh',
         options: Options(headers: {'Authorization': 'Bearer $refresh'}),
       );
       final data = response.data as Map<String, dynamic>;
@@ -91,7 +91,7 @@ class ApiService {
 
 
   Future<Response> loginWithGoogle(String idToken) async =>
-      await _dio.post('/auth/auth/google', data: {'id_token': idToken});
+      await _dio.post('/auth/google', data: {'id_token': idToken});
 
   Future<void> submitOnboarding(Map<String, dynamic> data) async {
     final token = await getToken();


### PR DESCRIPTION
## Summary
- fix API base URL constant
- call correct auth endpoints in the Flutter client

## Testing
- `pip install -r requirements.txt` *(fails: cython_sources AttributeError)*
- `pytest -k 'dummy' -s` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ebb3e53648322b39054b4c9a3dee8