### PR TITLE
Fix duplicate methods in api_service

### DIFF
--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -93,17 +93,6 @@ class ApiService {
   Future<Response> loginWithGoogle(String idToken) async =>
       await _dio.post('/auth/google', data: {'id_token': idToken});
 
-  Future<Response> register(String email, String password) async =>
-      await _dio.post(
-        '/auth/auth/register',
-        data: {'email': email, 'password': password},
-      );
-
-  Future<Response> login(String email, String password) async =>
-      await _dio.post(
-        '/auth/auth/login',
-        data: {'email': email, 'password': password},
-      );
 
   Future<Response> register(String email, String password) async =>
       await _dio.post(


### PR DESCRIPTION
## Summary
- remove repeated `register` and `login` methods from `api_service.dart`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_686ec101d7888322b5914af0b53b3c31