### PR TITLE
Relax CSP for docs endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -120,7 +120,12 @@ async def security_headers(request: Request, call_next):
     )
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Content-Security-Policy"] = "default-src 'self'"
+    if request.url.path.startswith("/docs") or request.url.path.startswith("/redoc"):
+        response.headers[
+            "Content-Security-Policy"
+        ] = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+    else:
+        response.headers["Content-Security-Policy"] = "default-src 'self'"
     response.headers["Permissions-Policy"] = "geolocation=(), microphone=()"
     response.headers["Referrer-Policy"] = "same-origin"
     response.headers["X-XSS-Protection"] = "1; mode=block"


### PR DESCRIPTION
## Summary
- loosen content security policy headers for /docs and /redoc
- simplify security headers tests by using a lightweight FastAPI app
- ensure CSP contains `unsafe-inline` for docs

## Testing
- `pytest app/tests/test_security_headers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68701695b0b0832295518784e2b5119a