### PR TITLE
Fix budget endpoint dates

### DIFF
--- a/app/api/budget/routes.py
+++ b/app/api/budget/routes.py
@@ -1,34 +1,47 @@
+from datetime import datetime
+from typing import Optional
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from app.api.budget.services import (
-    fetch_remaining_budget,
-    fetch_spent_by_category,
-)
 from app.core.session import get_db
+
 # assumes User is defined in models
 from app.db.models.user import User
 from app.services.auth_dependency import get_current_user
+
+from app.api.budget.services import fetch_remaining_budget  # isort:skip
+from app.api.budget.services import fetch_spent_by_category  # isort:skip
+
 
 router = APIRouter(prefix="/budget", tags=["budget"])
 
 
 @router.get("/spent")
 async def spent(
-    user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    year: Optional[int] = None,
+    month: Optional[int] = None,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
 ):
     """Return spending amounts grouped by category."""
 
-    return fetch_spent_by_category(db, user.id, 2025, 5)
+    now = datetime.utcnow()
+    year = year or now.year
+    month = month or now.month
+    return fetch_spent_by_category(db, user.id, year, month)
 
 
 @router.get("/remaining")
 async def remaining(
-    user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    year: Optional[int] = None,
+    month: Optional[int] = None,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
 ):
     """Return the remaining budget for the month."""
 
-    return fetch_remaining_budget(db, user.id, 2025, 5)
+    now = datetime.utcnow()
+    year = year or now.year
+    month = month or now.month
+    return fetch_remaining_budget(db, user.id, year, month)

--- a/app/tests/test_budget_routes.py
+++ b/app/tests/test_budget_routes.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.budget import routes as budget_routes
+
+
+@pytest.mark.asyncio
+async def test_spent_defaults_to_current_date(monkeypatch):
+    captured = {}
+
+    async def dummy_fetch(db, user_id, year, month):
+        captured["args"] = (year, month)
+        return {"ok": True}
+
+    monkeypatch.setattr(budget_routes, "fetch_spent_by_category", dummy_fetch)
+    monkeypatch.setattr(
+        budget_routes, "get_current_user", lambda: SimpleNamespace(id="u1")
+    )
+    monkeypatch.setattr(budget_routes, "get_db", lambda: iter(["db"]))
+
+    now = datetime.utcnow()
+    result = await budget_routes.spent()
+
+    assert result == {"ok": True}
+    assert captured["args"] == (now.year, now.month)
+
+
+@pytest.mark.asyncio
+async def test_remaining_accepts_custom_date(monkeypatch):
+    captured = {}
+
+    async def dummy_fetch(db, user_id, year, month):
+        captured["args"] = (year, month)
+        return {"rem": True}
+
+    monkeypatch.setattr(budget_routes, "fetch_remaining_budget", dummy_fetch)
+    monkeypatch.setattr(
+        budget_routes, "get_current_user", lambda: SimpleNamespace(id="u1")
+    )
+    monkeypatch.setattr(budget_routes, "get_db", lambda: iter(["db"]))
+
+    result = await budget_routes.remaining(year=2030, month=12)
+
+    assert result == {"rem": True}
+    assert captured["args"] == (2030, 12)

--- a/app/tests/test_rq_scheduler.py
+++ b/app/tests/test_rq_scheduler.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+import types
+
+
+def test_monthly_redistribution_scheduled(monkeypatch):
+    jobs = []
+
+    class DummyScheduler:
+        def __init__(self, queue_name=None, connection=None):
+            pass
+
+        def cancel_all(self):
+            pass
+
+        def cron(self, cron_string, func, repeat=None, queue_name=None):
+            jobs.append((cron_string, func.__name__))
+
+    dummy_rq = types.ModuleType("rq_scheduler")
+    dummy_rq.Scheduler = DummyScheduler
+    monkeypatch.setitem(sys.modules, "rq_scheduler", dummy_rq)
+
+    dummy_redis = types.ModuleType("redis")
+    dummy_redis.Redis = types.SimpleNamespace(from_url=lambda url: None)
+    monkeypatch.setitem(sys.modules, "redis", dummy_redis)
+
+    import scripts.rq_scheduler as rq
+
+    importlib.reload(rq)
+
+    assert ("0 1 1 * *", "enqueue_monthly_redistribution") in jobs


### PR DESCRIPTION
## Summary
- make `/budget/spent` and `/budget/remaining` accept year/month params
- default year/month to current date
- add tests for the budget routes
- check that monthly redistribution job is scheduled

## Testing
- `pre-commit run --files app/api/budget/routes.py app/tests/test_budget_routes.py app/tests/test_rq_scheduler.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687c04ee5cec8322842f9801422eee3c