### PR TITLE
Unify JWT handling

### DIFF
--- a/app/api/auth/services.py
+++ b/app/api/auth/services.py
@@ -3,12 +3,8 @@ from sqlalchemy.orm import Session
 
 from app.api.auth.schemas import LoginIn  # noqa: E501
 from app.api.auth.schemas import GoogleAuthIn, RegisterIn, TokenOut
-from app.core.jwt_utils import (
-    create_access_token,
-    create_refresh_token,
-    hash_password,
-    verify_password,
-)
+from app.core.jwt_utils import hash_password, verify_password
+from app.services.auth_jwt_service import create_access_token, create_refresh_token
 from app.db.models import User
 from app.services.google_auth_service import authenticate_google_user
 from app.utils.response_wrapper import success_response

--- a/app/core/jwt_utils.py
+++ b/app/core/jwt_utils.py
@@ -1,39 +1,19 @@
-import datetime
-import uuid
 import jwt
 from passlib.context import CryptContext
 
-from app.core.config import SECRET_KEY, ALGORITHM, settings
-
-
-ACCESS_EXPIRES_MIN = settings.ACCESS_TOKEN_EXPIRE_MINUTES
-REFRESH_EXPIRES_DAYS = 7
+from app.core.config import SECRET_KEY, ALGORITHM
+from app.services import auth_jwt_service
 
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
-def create_token(data: dict, expires_delta: datetime.timedelta) -> str:
-    to_encode = data.copy()
-    to_encode.update({
-        "exp": datetime.datetime.utcnow() + expires_delta,
-        "jti": str(uuid.uuid4()),
-    })
-    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
-
-
 def create_access_token(user_id: str) -> str:
-    return create_token(
-        {"sub": str(user_id), "type": "access"},
-        datetime.timedelta(minutes=ACCESS_EXPIRES_MIN),
-    )
+    return auth_jwt_service.create_access_token({"sub": str(user_id)})
 
 
 def create_refresh_token(user_id: str) -> str:
-    return create_token(
-        {"sub": str(user_id), "type": "refresh"},
-        datetime.timedelta(days=REFRESH_EXPIRES_DAYS),
-    )
+    return auth_jwt_service.create_refresh_token({"sub": str(user_id)})
 
 
 def verify_password(plain: str, hashed: str) -> bool:

--- a/app/services/auth_jwt_service.py
+++ b/app/services/auth_jwt_service.py
@@ -1,41 +1,57 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
+import time
+import uuid
 
 from jose import JWTError, jwt
 
 from app.core.config import ALGORITHM, settings
+from app.core.upstash import (
+    blacklist_token as upstash_blacklist_token,
+    is_token_blacklisted,
+)
 
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 
-# Could be replaced by Redis/DB storage
-TOKEN_BLACKLIST = set()
 
-
-def _current_secret():
+def _current_secret() -> str:
     return settings.SECRET_KEY
 
 
-def _previous_secret():
+def _previous_secret() -> str | None:
     return settings.JWT_PREVIOUS_SECRET
 
 
-def create_access_token(data: dict, expires_delta: timedelta | None = None):
+def _create_token(data: dict, expires_delta: timedelta, scope: str) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (
-        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    expire = datetime.utcnow() + expires_delta
+    to_encode.update({
+        "exp": expire,
+        "scope": scope,
+        "jti": str(uuid.uuid4()),
+    })
+    return jwt.encode(to_encode, _current_secret(), algorithm=ALGORITHM)
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    return _create_token(
+        data,
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+        "access_token",
     )
-    to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, _current_secret(), algorithm=ALGORITHM)
 
 
-def create_refresh_token(data: dict):
-    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode = data.copy()
-    to_encode.update({"exp": expire, "scope": "refresh_token"})
-    return jwt.encode(to_encode, _current_secret(), algorithm=ALGORITHM)
+def create_refresh_token(data: dict) -> str:
+    return _create_token(
+        data,
+        timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+        "refresh_token",
+    )
 
 
-def verify_token(token: str, scope: str = "access_token"):
+def verify_token(token: str, scope: str = "access_token") -> dict | None:
     secrets = [_current_secret()]
     prev = _previous_secret()
     if prev:
@@ -46,7 +62,8 @@ def verify_token(token: str, scope: str = "access_token"):
             payload = jwt.decode(token, secret, algorithms=[ALGORITHM])
             if payload.get("scope") != scope:
                 raise JWTError("Invalid token scope")
-            if token in TOKEN_BLACKLIST:
+            jti = payload.get("jti")
+            if jti and is_token_blacklisted(jti):
                 raise JWTError("Token is blacklisted")
             return payload
         except JWTError:
@@ -54,5 +71,21 @@ def verify_token(token: str, scope: str = "access_token"):
     return None
 
 
-def blacklist_token(token: str):
-    TOKEN_BLACKLIST.add(token)
+def blacklist_token(token: str) -> None:
+    secrets = [_current_secret()]
+    prev = _previous_secret()
+    if prev:
+        secrets.append(prev)
+
+    for secret in secrets:
+        try:
+            payload = jwt.decode(token, secret, algorithms=[ALGORITHM])
+            jti = payload.get("jti")
+            exp = payload.get("exp")
+            if jti and exp:
+                ttl = max(0, int(exp - time.time()))
+                upstash_blacklist_token(jti, ttl)
+            break
+        except JWTError:
+            continue
+


### PR DESCRIPTION
## Summary
- consolidate JWT creation and verification under `auth_jwt_service`
- wrap password helpers in `jwt_utils` and delegate token creation to the unified service
- update dependencies and authentication services to use the single JWT implementation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687c0b5563d8832297ec12838e3bd799