### PR TITLE
Fix behavior import and worker compatibility

### DIFF
--- a/app/api/behavior/routes.py
+++ b/app/api/behavior/routes.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Depends
 
 from app.api.behavior.schemas import BehaviorPayload
+from app.api.behavior.services import generate_behavior
 from app.api.dependencies import get_current_user
-from app.services.behavior_service import generate_behavior
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/behavior", tags=["behavior"])

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,7 +1,16 @@
 import os
 
+import rq
 from redis import Redis
-from rq import Connection, Queue, Worker
+
+try:
+    from rq import Connection
+except ImportError:  # RQ>=2.0 no longer exposes Connection at top level
+    from rq.connections import Connection
+
+    rq.Connection = Connection  # provide backward-compatible attribute
+
+from rq import Queue, Worker
 
 redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 conn = Redis.from_url(redis_url)


### PR DESCRIPTION
## Summary
- update behavior router to use new service path
- remove obsolete behavior_service stub
- make worker compatible with RQ v2 by gracefully importing Connection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e2f5bc15c8322997fde43abb43b3e